### PR TITLE
fix/schedule-task error listener

### DIFF
--- a/Sources/TUSKit/TUSBackground.swift
+++ b/Sources/TUSKit/TUSBackground.swift
@@ -76,10 +76,10 @@ final class TUSBackground {
 
     func getPendingTasks(handler: @escaping ([BGTaskRequest]) -> Void) {
       #if targetEnvironment(simulator)
-        print("TUSClient background tasks aren't supported on simulator (iOS limitation). Ignoring.")
-        #else
-        BGTaskScheduler.shared.getPendingTaskRequests(completionHandler: handler)
-        #endif
+      print("TUSClient background tasks aren't supported on simulator (iOS limitation). Ignoring.")
+      #else
+      BGTaskScheduler.shared.getPendingTaskRequests(completionHandler: handler)
+      #endif
     }
     
     func scheduleBackgroundTasks() {

--- a/Sources/TUSKit/TUSBackground.swift
+++ b/Sources/TUSKit/TUSBackground.swift
@@ -64,10 +64,18 @@ final class TUSBackground {
         }
 #endif
     }
+
+    func getPendingTasks(handler: @escaping ([BGTaskRequest]) -> Void) {
+      #if targetEnvironment(simulator)
+        print("TUSClient background tasks aren't supported on simulator (iOS limitation). Ignoring.")
+        #else
+        BGTaskScheduler.shared.getPendingTaskRequests(completionHandler: handler)
+        #endif
+    }
     
     func scheduleBackgroundTasks() {
         #if targetEnvironment(simulator)
-        print("Background tasks aren't supported on simulator (iOS limitation). Ignoring.")
+        print("TUSClient background tasks aren't supported on simulator (iOS limitation). Ignoring.")
         #else
         scheduleSingleTask()
         #endif
@@ -84,9 +92,8 @@ final class TUSBackground {
         do {
             try BGTaskScheduler.shared.submit(request)
         } catch {
-            print("Could not schedule background task \(error)")
+            print("TUSClient could not schedule background task \(error)")
         }
-        
     }
     
     /// Return first available task

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -19,6 +19,8 @@ public protocol TUSClientDelegate: AnyObject {
     func didStartUpload(id: UUID, context: [String: String]?, client: TUSClient)
     /// `TUSClient` just finished an upload, returns the URL of the uploaded file.
     func didFinishUpload(id: UUID, url: URL, context: [String: String]?, client: TUSClient)
+    /// TUSBackgroundClient received an error from `BGTaskScheduler.scheduleSingleTask`
+    func scheduleSingleTaskFailed(error: Error)
     /// An upload failed. Returns an error. Could either be a TUSClientError or a networking related error.
     func uploadFailed(id: UUID, error: Error, context: [String: String]?, client: TUSClient)
     
@@ -81,7 +83,7 @@ public final class TUSClient {
 #if os(iOS)
     @available(iOS 13.0, *)
     private lazy var backgroundClient: TUSBackground = {
-        return TUSBackground(api: api, files: files, chunkSize: chunkSize)
+        return TUSBackground(api: api, files: files, chunkSize: chunkSize, delegate: self)
     }()
 #endif
     
@@ -608,6 +610,13 @@ extension TUSClient: ProgressDelegate {
         /* } */
 
         /* delegate?.totalProgress(bytesUploaded: totalBytesUploaded, totalBytes: totalSize, client: self) */
+    }
+}
+
+extension TUSClient: TUSBackgroundDelegate {
+    
+    public func scheduleSingleTaskFailed(error: Error) {
+        self.delegate?.scheduleSingleTaskFailed(error: error)
     }
 }
 

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -308,6 +308,11 @@ public final class TUSClient {
     public func scheduleBackgroundTasks() {
         backgroundClient.scheduleBackgroundTasks()
     }
+    
+    @available(iOS 13.0, *)
+    public func getPendingTasks(handler: @escaping ([BGTaskRequest]) -> Void) {
+        backgroundClient.getPendingTasks(handler: handler)
+    }
 #endif
     
     /// Return the id's all failed uploads. Good to check after launch or after background processing for example, to handle them at a later stage.

--- a/TUSKit.podspec
+++ b/TUSKit.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TUSKit'
-  s.version          = '3.1.3'
+  s.version          = '3.1.4'
   s.summary          = 'TUSKit client in Swift'
   s.swift_version = '5.0'
 


### PR DESCRIPTION
Adds an error listener for scheduleSingleTask so the caught error can be bubbled up to delegate. 
Adds a wrapper method for  `BGTaskScheduler. getPendingTaskRequests`