### PR TITLE
Feat/debug info

### DIFF
--- a/Sources/TUSKit/Files.swift
+++ b/Sources/TUSKit/Files.swift
@@ -211,6 +211,18 @@ final class Files {
             try FileManager.default.removeItem(at: storageDirectory)
         }
     }
-    
+
+    func getFilesToUploadCount() -> Int {
+        do {
+          let directoryContents = try FileManager.default.contentsOfDirectory(at: storageDirectory, includingPropertiesForKeys: nil)
+          
+          // if you want to filter the directory contents you can do like this:
+          let files = directoryContents.filter{ $0.pathExtension == "plist" }
+          return files.count
+        }
+        catch {
+            return 0
+        }
+    }
 }
 

--- a/Sources/TUSKit/Scheduler.swift
+++ b/Sources/TUSKit/Scheduler.swift
@@ -96,6 +96,13 @@ final class Scheduler {
         }
     }
 
+    func getInfoForTasks() -> (pendingTasksCount: Int, runningTasksCount: Int) {
+      return (
+        self.pendingTasks.count, 
+        self.runningTasks.count
+      )
+    }
+
     private func checkProcessNextTask() {
         queue.async { [weak self] in
             guard let self = self else { return }

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -148,6 +148,32 @@ public final class TUSClient {
         let tasksToCancel = scheduler.allTasks.filter { ($0 as? IdentifiableTask)?.id == id }
         scheduler.cancelTasks(tasksToCancel)
     }
+
+    /// Returns info for debugging 
+    /// - scheduler's pending tasks
+    /// - scheduler's running tasks
+    /// - api's maximum / current concurrent running uploads
+    /// - current running uploads
+    /// - files to upload
+    public func getInfo() -> (pendingTasksCount: Int, runningTasksCount: Int,
+                              maxConcurrentUploads: Int, currentConcurrentUploads: Int,
+                              runningUploadsCount: Int, filesToUploadCount: Int) {
+      let schedulerInfo = scheduler.getInfoForTasks()
+      let uploadInfo = api.getInfoForUploads()
+      let runningUploads = uploads.compactMap{ upload in
+        return upload
+      }.count
+      let filesToUpload = files.getFilesToUploadCount()
+
+      return (
+        pendingTasksCount: schedulerInfo.0,
+        runningTasksCount: schedulerInfo.1,
+        maxConcurrentUploads: uploadInfo.0,
+        currentConcurrentUploads: uploadInfo.1,
+        runningUploadsCount: runningUploads,
+        filesToUploadCount: filesToUpload
+      )
+    }
     
     /// This will cancel all running uploads and clear the local cache.
     /// Expect errors passed to the delegate for canceled tasks.

--- a/TUSKit.podspec
+++ b/TUSKit.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TUSKit'
-  s.version          = '3.1.6'
+  s.version          = '3.1.7'
   s.summary          = 'TUSKit client in Swift'
   s.swift_version = '5.0'
 


### PR DESCRIPTION
Adds a method to output
- pending/running tasks in scheduler
- semaphore limit and how many concurrent uploads are running at the time of calling the method
- TUSClient's `uploads` map count as well as the count of all metdata files in the directory where tuskit caches the metadata files