### PR TITLE
Fix/background upload progress

### DIFF
--- a/Sources/TUSKit/DebugOptions.swift
+++ b/Sources/TUSKit/DebugOptions.swift
@@ -1,0 +1,25 @@
+//
+//  DebugOptions.swift
+//  TUSKit
+//
+//  Created by Tom Greco on 7/10/22.
+//
+
+import Foundation
+
+/// Ignore print statements in release build
+public func print(_ object: Any...) {
+    #if DEBUG
+    for item in object {
+        Swift.print(item)
+    }
+    #endif
+}
+
+/// Ignore print statements in release build
+public func print(_ object: Any) {
+    #if DEBUG
+    Swift.print(object)
+    #endif
+}
+

--- a/Sources/TUSKit/TUSAPI.swift
+++ b/Sources/TUSKit/TUSAPI.swift
@@ -61,7 +61,8 @@ final class TUSAPI {
                       let length = Int(lengthStr),
                       let offsetStr = response.allHeaderFields[caseInsensitive: "upload-Offset"] as? String,
                       let offset = Int(offsetStr) else {
-                          throw TUSAPIError.couldNotFetchStatus
+                            print ("Could not fetch status")
+                            throw TUSAPIError.couldNotFetchStatus
                       }
 
                 return Status(length: length, offset: offset)
@@ -87,6 +88,7 @@ final class TUSAPI {
 
                 guard let location = response.allHeaderFields[caseInsensitive: "location"] as? String,
                       let locationURL = URL(string: location, relativeTo: metaData.uploadURL) else {
+                    print ("Could not retrieve location")
                     throw TUSAPIError.couldNotRetrieveLocation
                 }
 

--- a/Sources/TUSKit/TUSBackground.swift
+++ b/Sources/TUSKit/TUSBackground.swift
@@ -9,8 +9,6 @@ import Foundation
 import BackgroundTasks
 
 #if os(iOS)
-@available(iOS 13.0, *)
-typealias GetFirstTaskCompletion = (ScheduledTask?) -> ()
 
 /// Perform background uploading
 @available(iOS 13.0, *)
@@ -41,16 +39,13 @@ final class TUSBackground {
 #else
         BGTaskScheduler.shared.register(forTaskWithIdentifier: TUSBackground.identifier, using: nil) { [weak self] bgTask in
             guard let self = self else {
-                print("No reference to self?")
                 return
             }
             guard let backgroundTask = bgTask as? BGProcessingTask else {
-                print("No reference to bgTask")
                 return
             }
             
             guard let tusTask = self.firstRunnableTask() else {
-                print("No task to run")
                 backgroundTask.setTaskCompleted(success: true)
                 return
             }

--- a/Sources/TUSKit/TUSBackground.swift
+++ b/Sources/TUSKit/TUSBackground.swift
@@ -10,57 +10,108 @@ import BackgroundTasks
 
 #if os(iOS)
 @available(iOS 13.0, *)
+typealias GetFirstTaskCompletion = (ScheduledTask?) -> ()
+
 /// Perform background uploading
+@available(iOS 13.0, *)
 final class TUSBackground {
     
     // Same as in the Info.plist `Permitted background task scheduler identifiers`
     private static let identifier = "io.tus.uploading"
     
-    private var currentTask: ScheduledTask?
+    // Restrict maximum running tasks
+    private var maxConcurrentTasks: Int
+    
+    private var pendingTasks: [ScheduledTask] = []
+    private var runningTasks: [ScheduledTask] = []
     private let api: TUSAPI
     private let files: Files
     private let chunkSize: Int
     
-    init(api: TUSAPI, files: Files, chunkSize: Int) {
+    init(api: TUSAPI, files: Files, chunkSize: Int, maxConcurrentTasks: Int) {
         self.api = api
         self.files = files
         self.chunkSize = chunkSize
+        self.maxConcurrentTasks = maxConcurrentTasks
     }
     
     func registerForBackgroundTasks() {
 #if targetEnvironment(simulator)
         return
 #else
-        BGTaskScheduler.shared.register(forTaskWithIdentifier: type(of: self).identifier, using: nil) { [weak self] bgTask in
-            guard let self = self else { return }
+        BGTaskScheduler.shared.register(forTaskWithIdentifier: TUSBackground.identifier, using: nil) { [weak self] bgTask in
+            guard let self = self else {
+                print("No reference to self?")
+                return
+            }
             guard let backgroundTask = bgTask as? BGProcessingTask else {
+                print("No reference to bgTask")
                 return
             }
             
-            guard let tusTask = self.firstTask() else {
+            guard let tusTask = self.firstRunnableTask() else {
+                print("No task to run")
                 backgroundTask.setTaskCompleted(success: true)
                 return
             }
             
-            self.currentTask = tusTask
-                    
+            // Mark task as running
+            self.movePendingTaskToRunning(task: tusTask)
+            
             backgroundTask.expirationHandler = {
+                print("Task expired")
+                // Remove UUID so tasks can be spawned for this file
+                self.removeRunningTask(task: tusTask)
+                
                 // Clean up so app won't get terminated and negatively impact iOS'background rating.
                 tusTask.cancel()
+                
+                self.scheduleSingleTask()
             }
             
-            tusTask.run { result in
-                switch result {
-                case .success:
-                    backgroundTask.setTaskCompleted(success: true)
-                case .failure:
-                    backgroundTask.setTaskCompleted(success: false)
+            print ("Running \(tusTask.taskType)")
+            do {
+                try tusTask.run { result in
+                    print ("\(tusTask.taskType) finished")
+                    
+                    // Remove UUID so tasks can be spawned for this file
+                    self.removeRunningTask(task: tusTask)
+                    
+                    var scheduled = false
+                    switch result {
+                    case .success(let newTasks):
+                        if(newTasks.count > 0) {
+                            self.scheduleSingleTask(inputTask: newTasks[0])
+                            scheduled = true
+                        }
+                        backgroundTask.setTaskCompleted(success: true)
+                    case .failure:
+                        backgroundTask.setTaskCompleted(success: false)
+                    }
+                    
+                    if(!scheduled) {
+                        self.scheduleSingleTask()
+                    }
                 }
+                
+                // Schedule as many concurrent tasks as possible
+                let runningTasks = self.runningTasks.count
+                if runningTasks < self.maxConcurrentTasks {
+                    self.scheduleSingleTask()
+                }
+            } catch let error {
+                print("\(tusTask.taskType) failed: \(error.localizedDescription)")
+                backgroundTask.setTaskCompleted(success: false)
+                self.scheduleSingleTask()
             }
-            
-            self.scheduleSingleTask() // Try and schedule another task.
         }
 #endif
+    }
+    
+    func getPendingBackgroundTasks () -> Void {
+        BGTaskScheduler.shared.getPendingTaskRequests { pendingTaskRequests in
+            print(pendingTaskRequests)
+        }
     }
     
     func scheduleBackgroundTasks() -> Bool {
@@ -68,42 +119,89 @@ final class TUSBackground {
         print("Background tasks aren't supported on simulator (iOS limitation). Ignoring.")
         return false
         #else
-        return scheduleSingleTask()
+        return self.scheduleSingleTask()
         #endif
     }
     
     /// Try and schedule another task. But, might not schedule a task if none are available.
-    private func scheduleSingleTask() -> Bool {
-        guard firstTask() != nil else {
+    private func scheduleSingleTask(inputTask: ScheduledTask? = nil) -> Bool {
+        guard let task = (inputTask == nil ? firstScheduableTask() : inputTask) else {
+            print("Skipping scheduleSingleTask")
             return false
         }
         
-        let request = BGProcessingTaskRequest(identifier: type(of: self).identifier)
+        let request = BGProcessingTaskRequest(identifier: TUSBackground.identifier)
         request.requiresNetworkConnectivity = true
         do {
+            print("\(task.taskType) submitted")
             try BGTaskScheduler.shared.submit(request)
+            
+            // Keep track of pending tasks so we don't spam 1000 of the same task.
+            // Task is pending until OS decides when BGTaskScheduler.shared.register
+            // should pick up the task and run it, but parent will typically call this
+            // method whenever app goes into background
+            self.pendingTasks.append(task)
+            //self.getPendingBackgroundTasks()
             return true
         } catch {
             print("Could not schedule background task \(error)")
             return false
         }
-        
+    }
+    
+    private func firstRunnableTask() -> ScheduledTask? {
+        return firstTask(filterOnPending: true)
+    }
+    
+    //
+    private func firstScheduableTask() -> ScheduledTask? {
+        return firstTask()
     }
     
     /// Return first available task
+    /// - Parameter filterOnPending: If true will only return tasks that are not running and are currently in the pending list
+    /// - default is false and will only filter out running tasks and pending tasks
     /// - Returns: A possible task to run
-    private func firstTask() -> ScheduledTask? {
+    private func firstTask(filterOnPending: Bool = false) -> ScheduledTask? {
         guard let allMetaData = try? files.loadAllMetadata() else {
             return nil
         }
         
-        return allMetaData.firstMap { metaData in
+        // Filter out running tasks
+        let filteredMetaData = allMetaData.filter { metaData in
+            let isRunning = self.runningTasks.firstIndex(where: {$0.id == metaData.id }) != nil
+            if isRunning {
+                return false
+            }
+            
+            let isPending = self.pendingTasks.firstIndex(where: {$0.id == metaData.id }) != nil
+            return filterOnPending ? isPending : !isPending
+        }
+        
+        return filteredMetaData.firstMap { metaData in
             try? taskFor(metaData: metaData, api: api, files: files, chunkSize: chunkSize)
         }
     }
     
+    private func removeRunningTask(task: ScheduledTask) -> Void {
+        let taskIndex = self.runningTasks.firstIndex(where: {$0 === task})
+        if (taskIndex != nil) {
+            self.runningTasks.remove(at: taskIndex!)
+        }
+    }
+    
+    private func removePendingTask(task: ScheduledTask) -> Void {
+        let taskIndex = self.pendingTasks.firstIndex(where: {$0 === task})
+        if (taskIndex != nil) {
+            self.pendingTasks.remove(at: taskIndex!)
+        }
+    }
+    
+    private func movePendingTaskToRunning(task: ScheduledTask) -> Void {
+        self.removePendingTask(task: task)
+        self.runningTasks.append(task)
+    }
 }
-
 private extension Array {
     /// `firstMap` is like `first(where:)`, but instead of returning the first element of the array, it returns the first transformed (mapped) element .
     /// You have to pass a `transform` closure. Whatever non-nil you return, will be returned from the method.

--- a/Sources/TUSKit/TUSClientUpdate.swift
+++ b/Sources/TUSKit/TUSClientUpdate.swift
@@ -1,0 +1,26 @@
+//
+//  TUSClientUpdate.swift
+//  TUSKit
+//
+//  Created by Tom Greco on 7/8/22.
+//
+
+import Foundation
+
+/// When react-native app is ready it will call TUSClient.sync
+/// to get in-sync with current progress that may have occurred in background tasks
+public struct TUSClientUpdate {
+    let id: UUID
+    let bytesUploaded: Int
+    let size: Int
+    let errorCount: Int
+    let name: String
+    
+    public init(id: UUID, bytesUploaded: Int, size: Int, errorCount: Int, name: String) {
+        self.id = id
+        self.bytesUploaded = bytesUploaded
+        self.size = size
+        self.errorCount = errorCount
+        self.name = name
+    }
+}

--- a/Sources/TUSKit/Tasks/IdentifiableTask.swift
+++ b/Sources/TUSKit/Tasks/IdentifiableTask.swift
@@ -6,7 +6,3 @@
 //
 
 import Foundation
-
-protocol IdentifiableTask: ScheduledTask {
-    var id: UUID { get }
-}

--- a/Sources/TUSKit/Tasks/StatusTask.swift
+++ b/Sources/TUSKit/Tasks/StatusTask.swift
@@ -8,13 +8,14 @@
 import Foundation
 
 /// A `StatusTask` fetches the status of an upload. It fetches the offset from we can continue uploading, and then makes a possible uploadtask.
-final class StatusTask: IdentifiableTask {
+final class StatusTask: ScheduledTask {
     
     // MARK: - IdentifiableTask
     
     var id: UUID {
         metaData.id
     }
+    var taskType: String = "StatusTask"
     
     weak var progressDelegate: ProgressDelegate?
     let api: TUSAPI

--- a/Sources/TUSKit/Tasks/UploadDataTask.swift
+++ b/Sources/TUSKit/Tasks/UploadDataTask.swift
@@ -9,13 +9,14 @@ import Foundation
 
 /// The upload task will upload to data a destination.
 /// Will spawn more UploadDataTasks if an upload isn't complete.
-final class UploadDataTask: NSObject, IdentifiableTask {
+final class UploadDataTask: NSObject, ScheduledTask {
     
     // MARK: - IdentifiableTask
     
     var id: UUID {
         metaData.id
     }
+    var taskType: String = "UploadDataTask"
     
     weak var progressDelegate: ProgressDelegate?
     let metaData: UploadMetadata

--- a/TUSKit.podspec
+++ b/TUSKit.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TUSKit'
-  s.version          = '3.1.11'
+  s.version          = '3.1.12'
   s.summary          = 'TUSKit client in Swift'
   s.swift_version = '5.0'
 


### PR DESCRIPTION
- Disable print statements in release build (I added more print statements to debug background uploads easier)
- Marked ScheduledTask.run with throws so any exceptions that occur in API call can be caught
- Background scheduler now keeps track of pending and running tasks so it can enforce a limit on maximum concurrent running tasks. Also allows for it to filter out scheduling tasks for files it already has a task scheduled for.
- Background scheduler will schedule the task returned in task.run. For example when StatusTask returns an UploadDataTask, that will be scheduled in order to prioritize a file and get it fully uploaded instead of uploading 1 chunk from every file.
- TUSClient has a sync method which allows react-native app to call it and get updates that occurred from background uploads and stay in sync. 