### PR TITLE
Refactor/one chunk to rule them all

### DIFF
--- a/Sources/TUSKit/BridgingHeader.h
+++ b/Sources/TUSKit/BridgingHeader.h
@@ -1,0 +1,13 @@
+//
+//  Header.h
+//  
+//
+//  Created by Tom Greco on 8/9/22.
+//
+
+#ifndef Header_h
+#define Header_h
+
+#include <os/proc.h>
+
+#endif /* Header_h */

--- a/Sources/TUSKit/Files.swift
+++ b/Sources/TUSKit/Files.swift
@@ -13,7 +13,7 @@ enum FilesError: Error {
 }
 
 extension FilesError {
-    public var errorDescription: String? {
+    public var localizedDescription: String? {
         switch self {
         case .metaDataFileNotFound:
             return NSLocalizedString("Metadata.plist file could not be found", comment: "RELATED_FILE_NOT_FOUND")
@@ -177,7 +177,7 @@ final class Files {
         
         // Write to disk
         try data.write(to: truncatedChunkPath, options: .atomic)
-        print("truncateChunk: Wrote \(offset) bytes to \(truncatedChunkPath) for \(metaData.id.uuidString)")
+        print("truncateChunk: Wrote \(data.count) bytes to \(truncatedChunkPath) for \(metaData.id.uuidString)")
         
         metaData.truncatedFileName = truncatedFileName
         metaData.truncatedOffset += (offset - metaData.truncatedOffset)
@@ -206,7 +206,7 @@ final class Files {
         let fileSize = try getFileSize(filePath: location)
         var currentSize = 0
         var chunk = 0
-        var range = 0..<min(chunkSize, fileSize)
+        var range = 0..<min(chunkSize == -1 ? fileSize : chunkSize, fileSize)
         while (range.upperBound <= fileSize && range.upperBound != range.lowerBound) {
             let fileName = "\(chunk).\(location.pathExtension)"
             let chunkPathInUuidDir = uuidDir.appendingPathComponent(fileName)
@@ -217,7 +217,7 @@ final class Files {
             //print("Containing data \(range.lowerBound) - \(range.upperBound)")
             //print("File handle offset: \(try fileHandle.offset())")
             try data.write(to: chunkPathInUuidDir, options: .atomic)
-            range = range.upperBound..<min(range.upperBound + chunkSize, fileSize)
+            range = range.upperBound..<min(range.upperBound + (chunkSize == -1 ? fileSize : chunkSize), fileSize)
             chunk += 1
         }
         

--- a/Sources/TUSKit/Files.swift
+++ b/Sources/TUSKit/Files.swift
@@ -177,7 +177,7 @@ final class Files {
         
         // Write to disk
         try data.write(to: truncatedChunkPath, options: .atomic)
-        print("truncateChunk: Wrote \(data.count) bytes to \(truncatedChunkPath) for \(metaData.id.uuidString)")
+        //print("truncateChunk: Wrote \(data.count) bytes to \(truncatedChunkPath) for \(metaData.id.uuidString)")
         
         metaData.truncatedFileName = truncatedFileName
         metaData.truncatedOffset += (offset - metaData.truncatedOffset)
@@ -213,7 +213,7 @@ final class Files {
             
             try fileHandle.seek(toOffset: UInt64(range.startIndex))
             let data = fileHandle.readData(ofLength: range.count)
-            print("Writing chunk \(chunk) to \(chunkPathInUuidDir.absoluteString)")
+            //print("Writing chunk \(chunk) to \(chunkPathInUuidDir.absoluteString)")
             //print("Containing data \(range.lowerBound) - \(range.upperBound)")
             //print("File handle offset: \(try fileHandle.offset())")
             try data.write(to: chunkPathInUuidDir, options: .atomic)

--- a/Sources/TUSKit/TUSAPI.swift
+++ b/Sources/TUSKit/TUSAPI.swift
@@ -47,7 +47,14 @@ final class TUSAPI {
     @discardableResult
     func getUploadTask(metaData: UploadMetadata, currentChunkFileSize: Int) -> URLSessionUploadTask {
         
-        let offset = metaData.currentChunk * metaData.chunkSize + metaData.truncatedOffset
+        var offset = metaData.currentChunk * metaData.chunkSize + metaData.truncatedOffset
+        if(metaData.chunkSize == -1) {
+            if let range = metaData.uploadedRange {
+                offset = range.upperBound
+            } else {
+                offset = 0
+            }
+        }
         
         /// Use truncated file path if it exists, otherwise use prechunked file
         let fileName = "\(metaData.currentChunk).\(metaData.fileExtension)"

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -410,7 +410,7 @@ public final class TUSClient: NSObject {
     // MARK: - Tasks
     /// Validates if startTasks() can run since we only want one instance of it at a time ever
     private func canRunTasks(isFiltered: Bool) -> Bool {
-        // Prevent spamming this methodx
+        // Prevent spamming this method
         if isFiltered != true {
             if isStartingAllTasks {
                 return false

--- a/TUSKit.podspec
+++ b/TUSKit.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TUSKit'
-  s.version          = '4.0.2'
+  s.version          = '4.1.0'
   s.summary          = 'TUSKit client in Swift'
   s.swift_version = '5.0'
 


### PR DESCRIPTION
Setting TUS_CHUNK_SIZE_BYTES to -1 will cause it to try to upload the file all in one go without any chunking (unless error then it will chunk to account for offset).

Also added in a check so if os_proc_available_memory ever returns less than 300 MB free, all new downloads will be stopped. Session will be invalidated to free up that leaking URLSession delegate memory.