### PR TITLE
MMKV/Cache changes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "TUSKit",
-            dependencies: []),
+            dependencies: ["MMKV"]),
         .testTarget(
             name: "TUSKitTests",
             dependencies: ["TUSKit"],

--- a/Sources/TUSKit/BridgingHeader.h
+++ b/Sources/TUSKit/BridgingHeader.h
@@ -9,5 +9,6 @@
 #define Header_h
 
 #include <os/proc.h>
+#import <MMKV/MMKV.h>
 
 #endif /* Header_h */

--- a/Sources/TUSKit/Files.swift
+++ b/Sources/TUSKit/Files.swift
@@ -89,6 +89,7 @@ final class Files {
             }
         }
         
+       try makeDirectoryIfNeeded(nil)
        try self.convertOldCacheToMMKV()
     }
     

--- a/Sources/TUSKit/Files.swift
+++ b/Sources/TUSKit/Files.swift
@@ -1,6 +1,6 @@
 //
 //  Files.swift
-//  
+//
 //
 //  Created by Tjeerd in ‘t Veen on 15/09/2021.
 //
@@ -10,6 +10,8 @@ import Foundation
 enum FilesError: Error {
     case metaDataFileNotFound(uuid: String)
     case uuidDirectoryNotFound(uuid: String)
+    case uploadQueueMissing
+    case cantParseMMKV
 }
 
 extension FilesError: LocalizedError {
@@ -19,11 +21,17 @@ extension FilesError: LocalizedError {
             return NSLocalizedString("Metadata.plist file could not be found \(uuid)", comment: "RELATED_FILE_NOT_FOUND")
         case let .uuidDirectoryNotFound(uuid):
             return NSLocalizedString("UUID directory for file was not found \(uuid)", comment: "UUID_DIRECTORY_NOT_FOUND")
+        case let .uploadQueueMissing:
+            return NSLocalizedString("Upload queue not found", comment: "UPLOAD_QUEUE_NOT_FOUND")
+        case let .cantParseMMKV:
+            return NSLocalizedString("Cannot parse data inside MMKV", comment: "CANT_PARSE_MMKV")
         default:
             return NSLocalizedString("File error", comment: "FILE_ERROR")
         }
     }
 }
+
+let UPLOAD_QUEUE_KEY = "upload_queue"
 
 /// This type handles the storage for `TUSClient`
 /// It makes sure that files (that are to be uploaded) are properly stored, together with their metaData.
@@ -35,15 +43,14 @@ final class Files {
     private let fileQueue = DispatchQueue(label: "com.tuskit.files")
     private let uploadQueue = DispatchQueue(label: "com.tuskit.uploadqueue")
 
-    
-    private let metadataFileName = "metadata.plist"
-    
-    private let uploadQueueFileName = "upload_queue.plist"
-    
+    private let mmkv: MMKV
+
     /// Pass a directory to store the local cache in.
     /// - Parameter storageDirectory: Leave nil for the documents dir. Pass a relative path for a dir inside the documents dir. Pass an absolute path for storing files there.
     /// - Throws: File related errors when it can't make a directory at the designated path.
     init(storageDirectory: URL?) throws {
+        self.mmkv = MMKV(mmapID: "metadata")!
+        
         func removeLeadingSlash(url: URL) -> String {
             if url.absoluteString.first == "/" {
                 return String(url.absoluteString.dropFirst())
@@ -89,22 +96,23 @@ final class Files {
     }
     
     func printFileDirContents(url: URL) throws {
-        let contents = try self.contentsOfDirectory(directory: url)
+        let contents = try self.contentsOfDirectory(directory: self.storageDirectory)
         print(contents)
+        
+        let contents2 = try self.contentsOfDirectory(directory: url)
+        print(contents2)
     }
     
     /// UploadQueue cannot exist in memory because it will need to be read from the background upload side of things which won't have access to TUSClient memory
     /// So load it from file every time you need to access it as well as write it back to disk every time you update the UploadQueue
     func loadUploadQueue() throws -> UploadQueue {
-        let decoder = PropertyListDecoder()
-        let uploadQueuePath = self.storageDirectory.appendingPathComponent(self.uploadQueueFileName)
-        if let data = try? Data(contentsOf: uploadQueuePath) {
-            guard let uploadQueue = try? decoder.decode(UploadQueue.self, from: data) else {
-                return UploadQueue()
-            }
-            return uploadQueue
+        guard let data = mmkv.data(forKey: UPLOAD_QUEUE_KEY) else {
+            return UploadQueue()
         }
-        return UploadQueue()
+        guard let uploadQueue = try? JSONDecoder().decode(UploadQueue.self, from: data) else {
+            return UploadQueue()
+        }
+        return uploadQueue
     }
     
     /// This needs to exist here so we can use the uploadQueue.sync
@@ -145,44 +153,62 @@ final class Files {
     func loadAllMetadata(_ filterOnUuids: [String]?) throws -> [UploadMetadata] {
         try fileQueue.sync {
 
-            let uuidDirs = try self.contentsOfDirectory(directory: storageDirectory).filter({  uuidDir in
-                if (uuidDir.lastPathComponent == uploadQueueFileName) {
+            let keys: [String] = (mmkv.allKeys() as! [String]).filter({  key in
+                print(key)
+                if(!key.contains("metadata:")) {
                     return false
                 }
+                let uuid = key.replacingOccurrences(of: "metadata:", with: "")
                 if filterOnUuids == nil {
                     return true
                 }
-                return filterOnUuids!.contains(where: { uuid in
-                    return uuid == uuidDir.lastPathComponent
+                return filterOnUuids!.contains(where: { filterUuid in
+                    return filterUuid == uuid as! String
                 })
-            })
+            }) as! [String]
             
-            // if you want to filter the directory contents you can do like this:
-            let decoder = PropertyListDecoder()
+            var metaDatas: [UploadMetadata] = []
             
-            let metaData: [UploadMetadata] = try uuidDirs.compactMap { uuidDir in
-                let uuidDirContents = try contentsOfDirectory(directory: uuidDir)
-                let metaDataUrls = uuidDirContents.filter{ $0.pathExtension == "plist" }
-                if(metaDataUrls.isEmpty) {
-                    try FileManager.default.removeItem(at: uuidDir)
-                    throw FilesError.metaDataFileNotFound(uuid: uuidDir.lastPathComponent)
+            do {
+                try keys.compactMap { key in
+                    let uuid = key.replacingOccurrences(of: "metadata:", with: "")
+                    guard let metaDataData = mmkv.data(forKey: key) else {
+                        throw FilesError.metaDataFileNotFound(uuid: uuid)
+                    }
+                    let str = String(data: metaDataData ?? Data(), encoding: .utf8) ?? ""
+                    let metaData = try JSONDecoder().decode(UploadMetadata.self, from: metaDataData)
+                    if(metaData != nil) {
+                        let uuidDir = storageDirectory.appendingPathComponent(uuid)
+                        let uuidDirContents = try contentsOfDirectory(directory: uuidDir)
+                        if(!uuidDirContents.isEmpty) {
+                            let metaDataUrl = uuidDirContents[0]
+                            
+                            
+                            // The documentsDirectory can change between restarts (at least during testing). So we update the filePath to match the existing plist again. To avoid getting an out of sync situation where the filePath still points to a dir in a different directory than the plist.
+                            // (The plist and file to upload should always be in the same dir together).
+                            metaData.fileDir = metaDataUrl.deletingLastPathComponent()
+                            metaDatas.append(metaData)
+                        }
+                    } else {
+                        print("Metadata: \(key)\n\(str)")
+                    }
                 }
-                let metaDataUrl = metaDataUrls[0]
-                if let data = try? Data(contentsOf: metaDataUrl) {
-                    let metaData = try? decoder.decode(UploadMetadata.self, from: data)
-                    
-                    // The documentsDirectory can change between restarts (at least during testing). So we update the filePath to match the existing plist again. To avoid getting an out of sync situation where the filePath still points to a dir in a different directory than the plist.
-                    // (The plist and file to upload should always be in the same dir together).
-                    metaData?.fileDir = metaDataUrl.deletingLastPathComponent()
-                    
-                    return metaData
-                }
-                
-                // Improvement: Handle error when it can't be decoded?
-                return nil
+            } catch DecodingError.dataCorrupted(let context) {
+                print(context)
+            } catch DecodingError.keyNotFound(let key, let context) {
+                print("Key '\(key)' not found:", context.debugDescription)
+                print("codingPath:", context.codingPath)
+            } catch DecodingError.valueNotFound(let value, let context) {
+                print("Value '\(value)' not found:", context.debugDescription)
+                print("codingPath:", context.codingPath)
+            } catch DecodingError.typeMismatch(let type, let context) {
+                print("Type '\(type)' mismatch:", context.debugDescription)
+                print("codingPath:", context.codingPath)
+            } catch {
+                print("error: ", error)
             }
             
-            return metaData
+            return metaDatas
         }
     }
     
@@ -253,6 +279,20 @@ final class Files {
         let fileSize = try getFileSize(filePath: location)
         var currentSize = 0
         var chunk = 0
+        
+        // Check if react-native side has cached file already for us
+        if(chunkSize == -1) {
+            let fileName = "0.\(location.pathExtension)"
+            let firstChunk = uuidDir.appendingPathComponent(fileName)
+            let doesExist = FileManager.default.fileExists(atPath: firstChunk.path, isDirectory: nil)
+            print(firstChunk.path)
+            if(doesExist) {
+                return uuidDir
+            } else {
+                try? printFileDirContents(url: uuidDir)
+            }
+        }
+        
         var range = 0..<min(chunkSize == -1 ? fileSize : chunkSize, fileSize)
         while (range.upperBound <= fileSize && range.upperBound != range.lowerBound) {
             let fileName = "\(chunk).\(location.pathExtension)"
@@ -271,15 +311,17 @@ final class Files {
         return uuidDir
     }
     
-    /// Removes metadata and its related file from disk
+    /// Removes metadata from MMKV but leaves file on disk. RN side will verify file was received by server before removing file from cache.
     /// - Parameter metaData: The metadata description
     /// - Parameter updateManifest: Defaults to true, but if false will not update manifest (useful if removing all files for a manifest)
     /// - Throws: Any error from FileManager when removing a file.
     func removeFile(_ metaData: UploadMetadata, _ updateManifest: Bool = true) throws {
         let fileDir = metaData.fileDir
+        print(fileDir)
         
         try fileQueue.sync {
-            try FileManager.default.removeItem(at: fileDir)
+            mmkv.removeValue(forKey: "metadata:\(metaData.id.uuidString)")
+            //try FileManager.default.removeItem(at: fileDir)
         }
         
         try uploadQueue.sync {
@@ -325,19 +367,10 @@ final class Files {
     /// - Throws: Any error related to file handling
     /// - Returns: The URL of the location where the metadata is stored.
     @discardableResult
-    func encodeAndStore(metaData: UploadMetadata) throws -> URL {
+    func encodeAndStore(metaData: UploadMetadata) throws -> Void {
         try fileQueue.sync {
-            guard FileManager.default.fileExists(atPath: metaData.fileDir.path) else {
-                // Could not find the directory that's related to this metadata.
-                throw FilesError.uuidDirectoryNotFound(uuid: metaData.id.uuidString)
-            }
-            
-            let targetLocation = metaData.fileDir.appendingPathComponent(metadataFileName)
-            
-            let encoder = PropertyListEncoder()
-            let encodedData = try encoder.encode(metaData)
-            try encodedData.write(to: targetLocation, options: .atomic)
-            return targetLocation
+            let encodedData = try JSONEncoder().encode(metaData)
+            mmkv.set(encodedData, forKey: "metadata:\(metaData.id.uuidString)")
         }
     }
     
@@ -347,11 +380,8 @@ final class Files {
     /// - Throws: Any error related to file handling
     @discardableResult
     func encodeAndStoreUploadQueue(_ queueToEncode: UploadQueue) throws {
-        let uploadQueuePath =  storageDirectory.appendingPathComponent(uploadQueueFileName)
-       
-        let encoder = PropertyListEncoder()
-        let encodedData = try encoder.encode(queueToEncode)
-        try encodedData.write(to: uploadQueuePath, options: .atomic)
+        let encodedData = try JSONEncoder().encode(queueToEncode)
+        mmkv.set(encodedData, forKey: UPLOAD_QUEUE_KEY)
     }
     
     /// Load metadata from store and find matching one by id

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -27,7 +27,7 @@ public protocol TUSClientDelegate: AnyObject {
 }
 
 let UPLOAD_MANIFEST_METADATA_KEY = "upload_manifest_id"
-
+let CLIENT_REF_ID_KEY = "client_ref_id"
 
 /// The TUSKit client.
 /// Please refer to the Readme.md on how to use this type.
@@ -224,6 +224,9 @@ public final class TUSClient: NSObject {
             var id: UUID
             if (uploadId != nil) {
                 id = UUID(uuidString: uploadId as! String)!
+            } else if((context?[CLIENT_REF_ID_KEY]) != nil) {
+                // Use UUID generated in react-native if possible
+                id = UUID(uuidString: context![CLIENT_REF_ID_KEY]!) ?? UUID()
             } else {
                 id = UUID()
             }
@@ -784,7 +787,7 @@ public final class TUSClient: NSObject {
                     // Create a truncated copy of the current chunked file that starts from expected offset
                     try files?.truncateChunk(metaData: metaData, offset: offsetDifference)
                     
-                    delegate?.progressFor(id: metaData.id, bytesUploaded: metaData.chunkSize == -1 ? offsetDifference : (metaData.uploadedRange?.upperBound ?? 0), totalBytes: metaData.size)
+                    /*delegate?.progressFor(id: metaData.id, bytesUploaded: metaData.chunkSize == -1 ? offsetDifference : (metaData.uploadedRange?.upperBound ?? 0), totalBytes: metaData.size)*/
                     currentChunkFileSize = try getChunkSize(for: metaData)
                 }
                 

--- a/Sources/TUSKit/TUSClient.swift
+++ b/Sources/TUSKit/TUSClient.swift
@@ -21,7 +21,7 @@ public protocol TUSClientDelegate: AnyObject {
     
     /// Receive confirmation that cancel operation has finished
     func cancelFinished(errorMessage: String?)
-
+    
     /// Get the progress of a specific upload by id. The id is given when adding an upload and methods of this delegate.
     func progressFor(id: UUID, bytesUploaded: Int, totalBytes: Int)
 }
@@ -71,7 +71,7 @@ public final class TUSClient: NSObject {
     public private (set) var isPaused: Bool = false
     
     public var isFifoQueueEnabled: Bool = true
-        
+    
     /// When uploadFiles runs this is set to true to prevent startTasks from running
     public private (set) var isBatchProcessingFile: Bool = false
     
@@ -84,7 +84,7 @@ public final class TUSClient: NSObject {
     
     /// Used to determine how many concurrent tasks should run
     private let networkMonitor = NetworkMonitor.shared
-
+    
     
     /// Initialize a TUSClient
     /// - Parameters:
@@ -121,7 +121,7 @@ public final class TUSClient: NSObject {
     deinit {
         self.networkMonitor.stop()
     }
-
+    
     func initSession() {
         // https://developer.apple.com/documentation/foundation/url_loading_system/downloading_files_in_the_background
         let urlSessionConfig = URLSessionConfiguration.background(withIdentifier: sessionIdentifier)
@@ -145,7 +145,7 @@ public final class TUSClient: NSObject {
         self.api = TUSAPI(session: self.session!)
         self.isSessionInvalidated = false
     }
-
+    
     
     /// Will notify delegate when cancel has finished since URLSession requires completion handler
     /// to obtain reference to running tasks
@@ -173,7 +173,7 @@ public final class TUSClient: NSObject {
             }
         })
     }
-
+    
     /// Returns get for debugging
     /// - scheduler's pending tasks
     /// - scheduler's running tasks
@@ -181,29 +181,29 @@ public final class TUSClient: NSObject {
     /// - current running uploads
     /// - files to upload
     public func getInfo() -> [String:Any] {
-      let filesToUpload = files?.getFilesToUploadCount()
-      
-      do {
-          let uploadQueue = try files?.loadUploadQueue()
-          let queueOrder = uploadQueue?.uploadManifests.map { $0.uploadManifestId }
-          
-          let infoResult = [
-              "maxConcurrentUploadsWifi": maxConcurrentUploadsWifi,
-              "maxConcurrentUploadsNoWifi": maxConcurrentUploadsNoWifi,
-              "currentConcurrentUploads":  uploadTasksRunning,
-              "filesToUploadCount": filesToUpload ?? 0,
-              "queueOrder": queueOrder,
-              "isFifoQueueEnabled": isFifoQueueEnabled
-          ] as [String : Any]
-          
-          /*self.session?.getAllTasks(completionHandler: { [weak self] tasks in
-            print("Pending tasks count: \(tasks.count)")
-            })*/
-          
-          return infoResult
-      } catch let error {
-          return [:]
-      }
+        let filesToUpload = files?.getFilesToUploadCount()
+        
+        do {
+            let uploadQueue = try files?.loadUploadQueue()
+            let queueOrder = uploadQueue?.uploadManifests.map { $0.uploadManifestId }
+            
+            let infoResult = [
+                "maxConcurrentUploadsWifi": maxConcurrentUploadsWifi,
+                "maxConcurrentUploadsNoWifi": maxConcurrentUploadsNoWifi,
+                "currentConcurrentUploads":  uploadTasksRunning,
+                "filesToUploadCount": filesToUpload ?? 0,
+                "queueOrder": queueOrder,
+                "isFifoQueueEnabled": isFifoQueueEnabled
+            ] as [String : Any]
+            
+            /*self.session?.getAllTasks(completionHandler: { [weak self] tasks in
+             print("Pending tasks count: \(tasks.count)")
+             })*/
+            
+            return infoResult
+        } catch let error {
+            return [:]
+        }
     }
     
     
@@ -322,7 +322,7 @@ public final class TUSClient: NSObject {
         
         return uploads
     }
-
+    
     public func freeMemory() {
         if(!isSessionInvalidated) {
             self.session?.finishTasksAndInvalidate()
@@ -381,11 +381,11 @@ public final class TUSClient: NSObject {
         }
         let updates = updatesToSync.map { update in
             return [
-              "id": "\(update.id)",
-              "bytesUploaded": update.bytesUploaded,
-              "size": update.size,
-              "isError": update.errorCount >= retryCount,
-              "name": update.name
+                "id": "\(update.id)",
+                "bytesUploaded": update.bytesUploaded,
+                "size": update.size,
+                "isError": update.errorCount >= retryCount,
+                "name": update.name
             ]
         }
         updatesToSync.removeAll()
@@ -393,25 +393,25 @@ public final class TUSClient: NSObject {
     }
     
     // MARK: - Private
-
+    
     /// Builds a list of files and their current status so parent can stay in sync with TUSClient
     /// Also, checks for any uploads that are finished and remove them from the cache (Background uploads don't have clean up)
     private func getUpdatesToSync() {
         var uuid: String = ""
         do {
             try files?.loadAllMetadata(nil)
-            .forEach{ metaData in
-                uuid = metaData.id.uuidString
-                let tusClientUpdate = TUSClientUpdate(id: metaData.id,
-                                                      bytesUploaded: metaData.uploadedRange?.count ?? 0,
-                                                      size: metaData.size,
-                                                      errorCount: metaData.errorCount,
-                                                      name: metaData.context?["name"] ?? "")
-                if (metaData.isFinished) {
-                    try files?.removeFile(metaData)
+                .forEach{ metaData in
+                    uuid = metaData.id.uuidString
+                    let tusClientUpdate = TUSClientUpdate(id: metaData.id,
+                                                          bytesUploaded: metaData.uploadedRange?.count ?? 0,
+                                                          size: metaData.size,
+                                                          errorCount: metaData.errorCount,
+                                                          name: metaData.context?["name"] ?? "")
+                    if (metaData.isFinished) {
+                        try files?.removeFile(metaData)
+                    }
+                    updatesToSync.append(tusClientUpdate)
                 }
-                updatesToSync.append(tusClientUpdate)
-            }
         } catch let error {
             delegate?.fileError(id: uuid, errorMessage: error.localizedDescription)
         }
@@ -448,7 +448,7 @@ public final class TUSClient: NSObject {
         let filePath = metadata.fileDir.appendingPathComponent(fileName)
         return try files!.getFileSize(filePath: filePath)
     }
-  
+    
     // MARK: - Tasks
     /// Validates if startTasks() can run since we only want one instance of it at a time ever
     private func canRunTasks(isFiltered: Bool) -> Bool {
@@ -459,7 +459,7 @@ public final class TUSClient: NSObject {
             }
             isStartingAllTasks = true
         }
-      
+        
         // Prevent running a million requests on a multiplexed HTTP/2 connection
         if uploadTasksRunning >= maxConcurrentUploads {
             if isFiltered != true {
@@ -508,120 +508,141 @@ public final class TUSClient: NSObject {
             return
         }
         
-        autoreleasepool {
-            do {
-                if !canRunTasks(isFiltered: uuids != nil) {
-                    return
+        do {
+            if !canRunTasks(isFiltered: uuids != nil) {
+                return
+            }
+            
+            let uuidStrings = uuids?.map({ uuid in
+                return uuid.uuidString
+            })
+            var failedItems: [UploadMetadata] = []
+            let metaDataItemsUnfiltered = try files?.loadAllMetadata(uuidStrings) ?? []
+            
+            var metaDataItems: [UploadMetadata] = []
+            if (isFifoQueueEnabled) {
+                let uploadManifestQueue = try self.files!.loadUploadQueue()
+                let (priorityQueue, failedQueue) = queueMetadata(metadata: metaDataItemsUnfiltered, queue: uploadManifestQueue)
+                metaDataItems = priorityQueue
+                if (metaDataItems.count == 0) && processFailedItemsIfEmpty == true {
+                    metaDataItems += failedQueue
                 }
-                
-                let uuidStrings = uuids?.map({ uuid in
-                    return uuid.uuidString
-                })
-                var failedItems: [UploadMetadata] = []
-                var ignoredFromUploadManifestQueue: [UploadMetadata] = []
-                var metaDataItems = try files?.loadAllMetadata(uuidStrings).filter({ metaData in
-                    // Only allow uploads where errors are below an amount
-                    // Commented this out because it was impossible to make work with a queue, downside is if an item continually fails it will block the whole queue
-                    /*if metaData.errorCount > retryCount {
+            } else {
+                metaDataItems = metaDataItemsUnfiltered.filter({ metaData in
+                    if metaData.errorCount > self.retryCount {
                         failedItems.append(metaData)
                         return false
-                    } else {*/
-                        // Check priority of upload queue based on upload manifest ID metadata
-                    if(isFifoQueueEnabled) {
-                        let uploadManifestQueue = try self.files!.loadUploadQueue()
-                        let uploadManifestToPrioritize = uploadManifestQueue.first
-                        if(uploadManifestToPrioritize != nil) {
-                            let uploadManifestId = metaData.context?[UPLOAD_MANIFEST_METADATA_KEY]
-                            if(uploadManifestId != uploadManifestToPrioritize?.uploadManifestId) {
-                                ignoredFromUploadManifestQueue.append(metaData)
-                                return false
-                            }
-                        }
-                        return !metaData.isFinished
-                    } else {
-                        if metaData.errorCount > retryCount {
-                            failedItems.append(metaData)
-                            return false
-                        }
-                        return !metaData.isFinished
                     }
-                   // }
+                    return !metaData.isFinished
                 })
-                
-                // Safe guard in case the upload queue doesn't work properly to avoid dead locks
-                if(metaDataItems?.count ?? 0 == 0 && ignoredFromUploadManifestQueue.count > 0) {
-                    metaDataItems = ignoredFromUploadManifestQueue
-                }
-                
-                // If list exhausted, process failed items queue
-                if (metaDataItems?.count ?? 0 == 0) && processFailedItemsIfEmpty == true {
-                    //print("TUSClient processing failed queue")
+                if (metaDataItems.count == 0) && processFailedItemsIfEmpty == true {
                     metaDataItems = failedItems
                 }
-                
-                if metaDataItems?.count ?? 0 > 0 {
-                    // Prevent duplicate tasks
-                    self.session?.getAllTasks(completionHandler: { [weak self] tasks in
-                        //print("Pending tasks count: \(tasks.count)")
-                        var uuid: String = ""
-                        do {
-                            guard let self = self else { return }
-                            func toTaskIds() -> [String] {
-                                var runningTaskIds: [String] = []
-                                tasks.forEach { task in
-                                    do {
-                                        let uuid = try task.toTaskDescription()?.uuid
-                                        if uuid != nil {
-                                            runningTaskIds.append(uuid!)
-                                        }
-                                    } catch let error {
-                                        print(error)
-                                        if uuids == nil {
-                                            self.isStartingAllTasks = false
-                                            //print("isStartingAllTasks unlocked")
-                                        }
-                                        //print("isStartingAllTasks is still locked")
-                                        return
+            }
+            
+            if metaDataItems.count > 0 {
+                // Prevent duplicate tasks
+                self.session?.getAllTasks(completionHandler: { [weak self] tasks in
+                    //print("Pending tasks count: \(tasks.count)")
+                    var uuid: String = ""
+                    do {
+                        guard let self = self else { return }
+                        func toTaskIds() -> [String] {
+                            var runningTaskIds: [String] = []
+                            tasks.forEach { task in
+                                do {
+                                    let uuid = try task.toTaskDescription()?.uuid
+                                    if uuid != nil {
+                                        runningTaskIds.append(uuid!)
                                     }
-                                }
-                                return runningTaskIds
-                            }
-                            let runningTaskIds = toTaskIds()
-                            
-                            for metaData in metaDataItems! {
-                                uuid = metaData.id.uuidString
-                                
-                                // Prevent running a million requests on a multiplexed HTTP/2 connection
-                                if !self.canRunTask(isFiltered: uuids != nil) {
+                                } catch let error {
+                                    print(error)
+                                    if uuids == nil {
+                                        self.isStartingAllTasks = false
+                                        //print("isStartingAllTasks unlocked")
+                                    }
+                                    //print("isStartingAllTasks is still locked")
                                     return
                                 }
-                                
-                                // Prevent running duplicates
-                                let isRunning = runningTaskIds.firstIndex(where: {$0 == metaData.id.uuidString }) != nil
-                                if !isRunning {
-                                    try self.startTask(for: metaData)
-                                }
+                            }
+                            return runningTaskIds
+                        }
+                        let runningTaskIds = toTaskIds()
+                        
+                        for metaData in metaDataItems {
+                            uuid = metaData.id.uuidString
+                            
+                            // Prevent running a million requests on a multiplexed HTTP/2 connection
+                            if !self.canRunTask(isFiltered: uuids != nil) {
+                                return
                             }
                             
-                            self.isStartingAllTasks = false
-                        } catch let error {
-                            if uuids == nil {
-                                self?.isStartingAllTasks = false
+                            // Prevent running duplicates
+                            let isRunning = runningTaskIds.firstIndex(where: {$0 == metaData.id.uuidString }) != nil
+                            if !isRunning {
+                                try self.startTask(for: metaData)
                             }
-                            self?.delegate?.fileError(id: uuid, errorMessage: "Start Tasks getAllTasks: \(error.localizedDescription)")
-                            print(error)
                         }
-                    })
-                } else {
-                    self.isStartingAllTasks = false
+                        
+                        self.isStartingAllTasks = false
+                    } catch let error {
+                        if uuids == nil {
+                            self?.isStartingAllTasks = false
+                        }
+                        self?.delegate?.fileError(id: uuid, errorMessage: "Start Tasks getAllTasks: \(error.localizedDescription)")
+                        print(error)
+                    }
+                })
+            } else {
+                self.isStartingAllTasks = false
+            }
+        } catch (let error) {
+            if uuids == nil {
+                isStartingAllTasks = false
+            }
+            delegate?.fileError(id: "", errorMessage: "Start Tasks: \(error.localizedDescription)")
+        }
+    }
+    
+    private func queueMetadata(metadata: [UploadMetadata], queue: UploadQueue) -> (priorityQueue: [UploadMetadata], failedQueue: [UploadMetadata]) {
+        var priorityQueue: [UploadMetadata] = []
+        var failedQueue: [UploadMetadata] = []
+        
+        for queueItem in queue.uploadManifests {
+            // filter, sort, and exclude finished metadata based on current queue item
+            let sortedMetadata = metadata.filter {
+                $0.context?[UPLOAD_MANIFEST_METADATA_KEY] == queueItem.uploadManifestId && !$0.isFinished
+            }.sorted {
+                guard let index1 = queueItem.uuids.firstIndex(of: $0.id),
+                      let index2 = queueItem.uuids.firstIndex(of: $1.id)
+                else { return false }
+                return index1 < index2
+            }
+            
+            for meta in sortedMetadata {
+                // if error count is over 5, add to failed queue and skip this iteration
+                if meta.errorCount > retryCount {
+                    failedQueue.append(meta)
+                    continue
                 }
-            } catch (let error) {
-                if uuids == nil {
-                    isStartingAllTasks = false
+                
+                // check if priority queue has reached max limit
+                if priorityQueue.count == maxConcurrentUploads {
+                    break
                 }
-                delegate?.fileError(id: "", errorMessage: "Start Tasks: \(error.localizedDescription)")
+                
+                // add metadata to priority queue
+                priorityQueue.append(meta)
+            }
+            
+            // if we have added any items to the priority queue, we can stop processing the next queues
+            if !priorityQueue.isEmpty && priorityQueue.count == maxConcurrentUploads {
+                break
             }
         }
+        
+        // return the priority and failed queues
+        return (priorityQueue, failedQueue)
     }
     
     /// Status task to find out where to continue from if endpoint exists in metadata,
@@ -640,12 +661,12 @@ public final class TUSClient: NSObject {
         if uploadTasksRunning >= maxConcurrentUploads {
             return
         }
-
-         // Prevent using invalidated session
+        
+        // Prevent using invalidated session
         if isSessionInvalidated {
             return
         }
-
+        
         uploadTasksRunning += 1
         
         if metaData.remoteDestination != nil {
@@ -665,7 +686,7 @@ public final class TUSClient: NSObject {
             
             // Load metadata from disk
             let metaData = try loadMetadata(for: id)
-        
+            
             // location is missing leading https://
             // Example: "//api.portal-beta.scanifly.com/surveyMedias/upload/files/33485c559ae35ab1bc76d91b4cebf95a"
             var remoteDestination = URL(string: location)
@@ -818,7 +839,7 @@ public final class TUSClient: NSObject {
                 // and spawns a creation or status task to take care of it
                 throw TUSAPIError.couldNotRetrieveOffset
             }
-        
+            
             
             let currentChunkFileSize = try getChunkSize(for: metaData)
             if(metaData.chunkSize != -1 && offset >= ((metaData.chunkSize * metaData.currentChunk) + currentChunkFileSize)) {
@@ -832,7 +853,7 @@ public final class TUSClient: NSObject {
             metaData.truncatedOffset = 0
             
             try saveMetadata(metaData: metaData)
-
+            
             if metaData.isFinished {
                 processFinishedFile(for: metaData)
                 return
@@ -859,9 +880,9 @@ public final class TUSClient: NSObject {
             //print("Uploading next \(newCurrentChunkFileSize) bytes for \(metaData.id.uuidString)\n-----")
             
             if !isSessionInvalidated {
-              api!.getUploadTask(metaData: metaData, currentChunkFileSize: newCurrentChunkFileSize).resume()
+                api!.getUploadTask(metaData: metaData, currentChunkFileSize: newCurrentChunkFileSize).resume()
             } else if uploadTasksRunning > 0 {
-              uploadTasksRunning -= 1
+                uploadTasksRunning -= 1
             }
         } catch let error {
             processFailedTask(for: id, errorMessage: "\(error.localizedDescription) - status code: \(response.statusCode)\n-----")
@@ -906,7 +927,7 @@ public final class TUSClient: NSObject {
             delegate?.fileError(id: id, errorMessage: "\(fileError.localizedDescription) \(errorMessage)" )
         }
     }
-        
+    
     private func processFinishedFile(for metaData: UploadMetadata) {
         //print("\(metaData.id.uuidString) finished")
         do {
@@ -936,13 +957,13 @@ extension TUSClient: URLSessionTaskDelegate {
     }
     
     /*public func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
-        print("didSendBody")
-    }
-
-    public func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
-        print("didFinishCollecting")
-    }*/
-
+     print("didSendBody")
+     }
+     
+     public func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
+     print("didFinishCollecting")
+     }*/
+    
     /// Called when task finishes, if error is nil then it completed successfully
     public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         //print("didComplete")
@@ -970,7 +991,7 @@ extension TUSClient: URLSessionTaskDelegate {
                 processFailedTask(for: taskDescription.uuid, errorMessage: error.localizedDescription)
                 return
             }
-
+            
             // No response
             if task.response == nil {
                 if uploadTasksRunning > 0 {
@@ -1021,7 +1042,7 @@ extension TUSClient: URLSessionDelegate {
             }
             completionHandler()
         }
-
+        
         if isSessionInvalidated {
             self.initSession()
             self.startTasks(for: nil)
@@ -1031,7 +1052,7 @@ extension TUSClient: URLSessionDelegate {
     public func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
         print("didBecomeInvalidWithError")
         print(error ?? "no error")
-
+        
         self.isSessionInvalidated = true
         self.initSession()
         self.startTasks(for: nil)

--- a/Sources/TUSKit/UploadMetada.swift
+++ b/Sources/TUSKit/UploadMetada.swift
@@ -31,24 +31,10 @@ final class UploadMetadata: Codable {
         case chunkSize
         case currentChunk
         case fileExtension
-        case status
     }
     
     var isFinished: Bool {
         size == uploadedRange?.count
-    }
-    
-    private var _status: String?
-    var status: String? {
-        get {
-            queue.sync {
-                _status
-            }
-        } set {
-            queue.async {
-                self._status = newValue
-            }
-        }
     }
     
     private var _id: UUID
@@ -190,7 +176,7 @@ final class UploadMetadata: Codable {
         }
     }
     
-    init(id: UUID, fileDir: URL, uploadURL: URL, size: Int, chunkSize: Int, fileExtension: String, truncatedFileName: String? = nil, customHeaders: [String: String]? = nil, mimeType: String? = nil, context: [String: String]? = nil, status: String? = nil) {
+    init(id: UUID, fileDir: URL, uploadURL: URL, size: Int, chunkSize: Int, fileExtension: String, truncatedFileName: String? = nil, customHeaders: [String: String]? = nil, mimeType: String? = nil, context: [String: String]? = nil) {
         self._id = id
         self._fileDir = fileDir
         self._truncatedFileName = truncatedFileName
@@ -205,7 +191,6 @@ final class UploadMetadata: Codable {
         self.version = 1 // Can't make default property because of Codable
         self.context = context
         self._errorCount = 0
-        self._status = status
     }
     
     init(from decoder: Decoder) throws {
@@ -226,7 +211,6 @@ final class UploadMetadata: Codable {
         fileExtension = try values.decode(String.self, forKey: .fileExtension)
         _currentChunk = try values.decode(Int.self, forKey: .currentChunk)
         _errorCount = try values.decode(Int.self, forKey: .errorCount)
-        _status = try values.decode(String?.self, forKey: .status)
     }
     
     func encode(to encoder: Encoder) throws {
@@ -247,6 +231,5 @@ final class UploadMetadata: Codable {
         try container.encode(fileExtension, forKey: .fileExtension)
         try container.encode(size, forKey: .size)
         try container.encode(_errorCount, forKey: .errorCount)
-        try container.encode(_status, forKey: .status)
     }
 }

--- a/Sources/TUSKit/UploadMetada.swift
+++ b/Sources/TUSKit/UploadMetada.swift
@@ -31,10 +31,24 @@ final class UploadMetadata: Codable {
         case chunkSize
         case currentChunk
         case fileExtension
+        case status
     }
     
     var isFinished: Bool {
         size == uploadedRange?.count
+    }
+    
+    private var _status: String?
+    var status: String? {
+        get {
+            queue.sync {
+                _status
+            }
+        } set {
+            queue.async {
+                self._status = newValue
+            }
+        }
     }
     
     private var _id: UUID
@@ -176,7 +190,7 @@ final class UploadMetadata: Codable {
         }
     }
     
-    init(id: UUID, fileDir: URL, uploadURL: URL, size: Int, chunkSize: Int, fileExtension: String, truncatedFileName: String? = nil, customHeaders: [String: String]? = nil, mimeType: String? = nil, context: [String: String]? = nil) {
+    init(id: UUID, fileDir: URL, uploadURL: URL, size: Int, chunkSize: Int, fileExtension: String, truncatedFileName: String? = nil, customHeaders: [String: String]? = nil, mimeType: String? = nil, context: [String: String]? = nil, status: String? = nil) {
         self._id = id
         self._fileDir = fileDir
         self._truncatedFileName = truncatedFileName
@@ -191,6 +205,7 @@ final class UploadMetadata: Codable {
         self.version = 1 // Can't make default property because of Codable
         self.context = context
         self._errorCount = 0
+        self._status = status
     }
     
     init(from decoder: Decoder) throws {
@@ -211,6 +226,7 @@ final class UploadMetadata: Codable {
         fileExtension = try values.decode(String.self, forKey: .fileExtension)
         _currentChunk = try values.decode(Int.self, forKey: .currentChunk)
         _errorCount = try values.decode(Int.self, forKey: .errorCount)
+        _status = try values.decode(String?.self, forKey: .status)
     }
     
     func encode(to encoder: Encoder) throws {
@@ -231,5 +247,6 @@ final class UploadMetadata: Codable {
         try container.encode(fileExtension, forKey: .fileExtension)
         try container.encode(size, forKey: .size)
         try container.encode(_errorCount, forKey: .errorCount)
+        try container.encode(_status, forKey: .status)
     }
 }

--- a/TUSKit.podspec
+++ b/TUSKit.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TUSKit'
-  s.version          = '4.4.0'
+  s.version          = '4.5.0'
   s.summary          = 'TUSKit client in Swift'
   s.swift_version = '5.0'
 

--- a/TUSKit.podspec
+++ b/TUSKit.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'TUSKit'
-  s.version          = '4.3.4'
+  s.version          = '4.4.0'
   s.summary          = 'TUSKit client in Swift'
   s.swift_version = '5.0'
 


### PR DESCRIPTION
TUSKit will check to see if a file exists in the cache directory before caching it.

This allows for image picker, camera, and gallery picker to write the file directly into TUSKit's cache to avoid duplicate caching between libraries.

TUSKit reads from MMKV keys to see which files need to be uploaded rather than scanning the cache directory. 
This is so other libraries can write to the cache directory and still have time to process other things before telling TUSKit to start uploading it.